### PR TITLE
Additional fixes requested by Alicia

### DIFF
--- a/js/Experiment2.js
+++ b/js/Experiment2.js
@@ -1,4 +1,5 @@
 const e2pos = Array.from({length: expt2_config.nPositions}, (_value, index) => (index));
+const re = /Picture\d+\.png/
 
 var usedStims, key;
 var targetsUsed = {};
@@ -179,6 +180,9 @@ const expt2_array = {
         if (!(key in targetsUsed)) targetsUsed[key] = [];
 
         // Stimuli aren't saved here yet as what gets saved will depend on probe
+    },
+    on_finish: function(data) {
+        data.stimulus = usedStims.map((x) => x.match(re)[0])
     },
     trial_duration: function(){
         let consolTime = genTime(

--- a/js/Experiment2.js
+++ b/js/Experiment2.js
@@ -87,7 +87,7 @@ const feedback = {
         // Instead, this function will check the accuracy of the last response and use that information to set
         // the stimulus value on each trial.
         if (jsPsych.timelineVariable('showFeedback')) {
-            var last_trial_correct = jsPsych.data.get().last(1).values()[0].correct;
+            var last_trial_correct = jsPsych.data.get().last(1).values()[0].accuracy;
             if(last_trial_correct) {
                 return '<img src=' +expt2_config.feedbackImgs[0]+ ' width="200" height="200"><h2>Correct!</h2>'; // the parameter value has to be returned from the function
             } else {
@@ -216,9 +216,9 @@ const expt2_response = {
         const novel_probe = jsPsych.timelineVariable('novel_probe');
 
         if (novel_probe) {
-            probe.file = usedStims.pop();
-        } else {
             probe.file = allStims.pop();
+        } else {
+            probe.file = usedStims.pop();
         }
 
         return [probe]

--- a/js/Experiment2.js
+++ b/js/Experiment2.js
@@ -65,7 +65,11 @@ const meta_capacity = {
     response_ends_trial: false,
     button_html: '<button class="jspsych-btn">%choice%</button>',
     data: {
-        screen: "meta"
+        screen: "meta",
+        metaType: jsPsych.timelineVariable('metaOptions')
+    },
+    on_finish: function(data) {
+        data.stimulus = jsPsych.current_trial.choices
     }
 };
 


### PR DESCRIPTION
1. Fixed bug: _When 'feedback' is `true` in Task 2, the feedback image that comes up always seems to be the negative (crying smiley "😭") one, even when the answer is correct?_
2. Saving additional data in output:
    - Added: _The specific images participants saw in Task 2 memory array_
    - Added: _The MetaOption in Task 2 (i.e., whether the participant saw the "number", "letter", or "delay" condition on that trial)_
    - Added: _The sequences of choices for the metaOptions into the data file?_
